### PR TITLE
chore: bump MSRV to 1.92, ignore dtolnay/rust-toolchain in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,5 +18,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "dtolnay/rust-toolchain"
     commit-message:
       prefix: "ci(deps)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.85"
+          toolchain: "1.92"
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "structured-public-domains"
 version = "0.0.2"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.92"
 authors = ["Structured World Foundation <foundation@sw.foundation>"]
 description = "Compact Public Suffix List (PSL) for Rust. ~35KB embedded JSON trie, O(depth) lookup. Auto-updated monthly from publicsuffix.org."
 documentation = "https://docs.rs/structured-public-domains/"


### PR DESCRIPTION
## Summary
- Bump `rust-version` in Cargo.toml: 1.85 → 1.92
- Update MSRV CI job toolchain: 1.85 → 1.92
- Exclude `dtolnay/rust-toolchain` from dependabot github-actions updates

Closes #11