### PR TITLE
feat: smart PSL auto-update with domain diff, drop zstd references

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Compact Public Suffix List (PSL) implementation for Rust. ~35KB embedded JSON trie compressed with zstd. O(depth) lookup. Checked daily against publicsuffix.org.
+Compact Public Suffix List (PSL) implementation for Rust. Zero dependencies, ~108KB embedded binary trie. O(depth * log k) lookup. Checked daily against publicsuffix.org.
 
 ## Review Scope Rules
 
@@ -12,4 +12,4 @@ Compact Public Suffix List (PSL) implementation for Rust. ~35KB embedded JSON tr
 
 - **No `unwrap()` or `expect()`** on any code path: `#[deny(clippy::unwrap_used, clippy::expect_used)]` enforced
 - **Clippy:** Must pass `cargo clippy --all-features -- -D warnings`
-- PSL data is auto-generated — do NOT manually edit `src/psl.json.zst` or generated data files
+- PSL data is auto-generated — do NOT manually edit `src/psl.bin` or generated data files

--- a/.github/workflows/update-psl.yml
+++ b/.github/workflows/update-psl.yml
@@ -31,9 +31,20 @@ jobs:
       - name: Check for rule changes
         id: diff
         run: |
-          # Extract only rules: strip comments/metadata, blank lines, sort, deduplicate.
+          # Extract and canonicalize rules identically to build-psl.py:
+          # strip comments/blanks, drop leading dot, lowercase — so case-only
+          # or dot-only upstream edits don't trigger false version bumps.
           extract_rules() {
-            grep -v '^[[:space:]]*//' "$1" | grep -v '^[[:space:]]*$' | sed 's/^[[:space:]]*//' | LC_ALL=C sort -u
+            python3 - "$1" <<'PY' | LC_ALL=C sort -u
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as f:
+    for raw in f:
+        line = raw.strip()
+        if not line or line.startswith("//"):
+            continue
+        print(line.lstrip(".").lower())
+PY
           }
 
           extract_rules data/public_suffix_list.dat > /tmp/rules-current.txt
@@ -45,9 +56,9 @@ jobs:
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
 
-            # Compute added/removed domains
-            comm -13 /tmp/rules-current.txt /tmp/rules-fresh.txt > /tmp/added.txt
-            comm -23 /tmp/rules-current.txt /tmp/rules-fresh.txt > /tmp/removed.txt
+            # Compute added/removed domains (LC_ALL=C matches sort collation)
+            LC_ALL=C comm -13 /tmp/rules-current.txt /tmp/rules-fresh.txt > /tmp/added.txt
+            LC_ALL=C comm -23 /tmp/rules-current.txt /tmp/rules-fresh.txt > /tmp/removed.txt
 
             ADDED=$(wc -l < /tmp/added.txt | tr -d ' ')
             REMOVED=$(wc -l < /tmp/removed.txt | tr -d ' ')

--- a/.github/workflows/update-psl.yml
+++ b/.github/workflows/update-psl.yml
@@ -98,6 +98,7 @@ PY
                 echo "Added (${ADDED}):"
                 head -50 /tmp/added.txt | sed 's/^/  + /'
                 [ "$ADDED" -gt 50 ] && echo "  ... and $((ADDED - 50)) more"
+                echo ""
               fi
               if [ "$REMOVED" -gt 0 ]; then
                 echo "Removed (${REMOVED}):"

--- a/.github/workflows/update-psl.yml
+++ b/.github/workflows/update-psl.yml
@@ -31,10 +31,9 @@ jobs:
       - name: Check for rule changes
         id: diff
         run: |
-          # Extract only rules: strip comments/metadata, blank lines, sort deterministically.
-          # Intentionally ignores VERSION/COMMIT header changes — only rule diffs matter.
+          # Extract only rules: strip comments/metadata, blank lines, sort, deduplicate.
           extract_rules() {
-            grep -v '^[[:space:]]*//' "$1" | grep -v '^[[:space:]]*$' | sed 's/^[[:space:]]*//' | LC_ALL=C sort
+            grep -v '^[[:space:]]*//' "$1" | grep -v '^[[:space:]]*$' | sed 's/^[[:space:]]*//' | LC_ALL=C sort -u
           }
 
           extract_rules data/public_suffix_list.dat > /tmp/rules-current.txt
@@ -45,8 +44,56 @@ jobs:
             echo "No rule changes detected"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "Rules changed:"
-            { diff --unified=0 /tmp/rules-current.txt /tmp/rules-fresh.txt || true; } | head -30
+
+            # Compute added/removed domains
+            comm -13 /tmp/rules-current.txt /tmp/rules-fresh.txt > /tmp/added.txt
+            comm -23 /tmp/rules-current.txt /tmp/rules-fresh.txt > /tmp/removed.txt
+
+            ADDED=$(wc -l < /tmp/added.txt | tr -d ' ')
+            REMOVED=$(wc -l < /tmp/removed.txt | tr -d ' ')
+            echo "added=$ADDED" >> "$GITHUB_OUTPUT"
+            echo "removed=$REMOVED" >> "$GITHUB_OUTPUT"
+            echo "Domain changes: +$ADDED -$REMOVED"
+
+            # Build PR body
+            {
+              echo "Automated daily PSL data refresh."
+              echo "Source: https://publicsuffix.org/list/public_suffix_list.dat"
+              echo ""
+              echo "## Domain changes: +${ADDED} -${REMOVED}"
+              echo ""
+              if [ "$ADDED" -gt 0 ]; then
+                echo "### Added (${ADDED})"
+                echo '```'
+                head -200 /tmp/added.txt
+                [ "$ADDED" -gt 200 ] && echo "... and $((ADDED - 200)) more"
+                echo '```'
+                echo ""
+              fi
+              if [ "$REMOVED" -gt 0 ]; then
+                echo "### Removed (${REMOVED})"
+                echo '```'
+                head -200 /tmp/removed.txt
+                [ "$REMOVED" -gt 200 ] && echo "... and $((REMOVED - 200)) more"
+                echo '```'
+              fi
+            } > /tmp/pr-body.md
+
+            # Build commit message
+            {
+              echo "feat(data): update PSL (+${ADDED} -${REMOVED})"
+              echo ""
+              if [ "$ADDED" -gt 0 ]; then
+                echo "Added (${ADDED}):"
+                head -50 /tmp/added.txt | sed 's/^/  + /'
+                [ "$ADDED" -gt 50 ] && echo "  ... and $((ADDED - 50)) more"
+              fi
+              if [ "$REMOVED" -gt 0 ]; then
+                echo "Removed (${REMOVED}):"
+                head -50 /tmp/removed.txt | sed 's/^/  - /'
+                [ "$REMOVED" -gt 50 ] && echo "  ... and $((REMOVED - 50)) more"
+              fi
+            } > /tmp/commit-msg.txt
           fi
 
       - name: Update data file
@@ -80,18 +127,26 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         run: cargo check --all-features
 
+      - name: Read commit message
+        if: steps.diff.outputs.changed == 'true'
+        id: commit-msg
+        run: |
+          {
+            echo "message<<COMMIT_EOF"
+            cat /tmp/commit-msg.txt
+            echo "COMMIT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create PR
         if: steps.diff.outputs.changed == 'true'
         id: pr
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.app-token.outputs.token }}
-          title: "chore(data): update PSL from publicsuffix.org"
-          body: |
-            Automated daily PSL data refresh.
-            Source: https://publicsuffix.org/list/public_suffix_list.dat
+          title: "feat(data): update PSL (+${{ steps.diff.outputs.added }} -${{ steps.diff.outputs.removed }})"
+          body-path: /tmp/pr-body.md
           branch: chore/psl-update
-          commit-message: "chore(data): update PSL from publicsuffix.org"
+          commit-message: ${{ steps.commit-msg.outputs.message }}
           delete-branch: true
 
       - name: Enable auto-merge

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Benchmarks on Apple M-series (criterion, `cargo bench`):
 | Lookup | O(depth) match tree | O(depth * log k) trie walk |
 | Auto-update | New crate version | Daily GitHub Actions check |
 
-Both crates have comparable lookup speed and zero runtime dependencies. `structured-public-domains` has ~8x smaller embedded data, ~50% less runtime memory (vs our previous JSON+zstd version), and daily auto-updates via GitHub Actions.
+Both crates have comparable lookup speed and zero runtime dependencies. `structured-public-domains` has ~8x smaller embedded data and auto-updates daily via GitHub Actions with domain-level changelogs.
 
 ## Support the Project
 


### PR DESCRIPTION
## Summary

- Overhaul `update-psl.yml`: sort+uniq rules, compute added/removed domains, include domain diff in PR body and commit message
- Change auto-update commit type to `feat(data)` so release-plz includes domain changes in changelog
- Only bump version when actual domain rules change — no-op on comment/metadata-only updates
- Remove all stale zstd references from `copilot-instructions.md` and `README.md`

## Why not zstd

Measured: zstd decoder (`structured-zstd`, pure Rust) adds ~133KB to final binary. Combined with 37KB compressed blob = 170KB, which is **more** than the 108KB uncompressed binary trie. Compression only saves space in git, not in the consumer's binary.

## Test Plan

- [x] 23/23 unit tests pass
- [x] Doc tests pass
- [x] Clippy clean (0 warnings)
- [x] Binary size: 451KB stripped (vs 468KB with zstd)

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated project description to state zero dependencies, an embedded binary trie, and revised lookup complexity.
  * Clarified that the project auto-updates daily via GitHub Actions and removed a prior memory-comparison claim.

* **Chores**
  * Improved update automation to canonicalize rules deterministically and compute domain-level added/removed sets.
  * Generates PR/commit artifacts with counts and samples, exposes the commit message as an action output, and uses dynamic PR title/body/commit-message.
  * Removed old unified-diff preview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->